### PR TITLE
feat(sqlite): Improve error messages for unsupported ALTER TABLE oper…

### DIFF
--- a/DebugHub/Sources/Models/Migrations.swift
+++ b/DebugHub/Sources/Models/Migrations.swift
@@ -31,10 +31,14 @@ struct CreateHTTPEvent: AsyncMigration {
             .field("trace_id", .string)
             .create()
 
-        // 创建索引
-        try await database.schema("http_events")
-            .unique(on: "id")
-            .update()
+        // Note: No need to add .unique(on: "id") constraint separately
+        // The id field with .identifier(auto: false) is already the primary key
+        // and primary keys are inherently unique
+        
+        // // 创建索引
+        // try await database.schema("http_events")
+        //     .unique(on: "id")
+        //     .update()
     }
 
     func revert(on database: Database) async throws {


### PR DESCRIPTION
…ations

Current error "SQLite only supports adding columns in ALTER TABLE statements" is unclear. Suggest showing which operation failed and how to fix it, e.g.: "Cannot add UNIQUE constraint via ALTER TABLE. Move constraint to .create() call."